### PR TITLE
Check url before validating item url

### DIFF
--- a/lib/PayPal/Api/Item.php
+++ b/lib/PayPal/Api/Item.php
@@ -199,8 +199,11 @@ class Item extends PayPalModel
      */
     public function setUrl($url)
     {
-        UrlValidator::validate($url, "Url");
-        $this->url = $url;
+        if ($url) {
+            UrlValidator::validate($url, "Url");
+            $this->url = $url;
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
We are seeing some errors on Farmison of `Url is not a fully qualified URL`, it looks like it comes from when the API response passes in empty `url` values for items and the validation in the PayPal sdk fails. Annoyingly it looks like an inconsistent problem where sometimes their API includes it and sometimes not.

So this is a change to not do the validation and setting if there is no value.

See https://www.farmison.com/cp/listing/store_transaction?filters=eJxdzFsKwjAQheG9zAq8ofVkHS7gIKkMhBo7EyWU7l3TQh98m%252Fk5fMQBk%252BECedDjh1UC13SFvAqT9hpHCfaLotaOM%252BTNVKK16R6TYrfWzJqZJMzz8prTi23eCeI1xyZ0kPtzcOrwDxqOkNu4IF%252F1GTFO

See loads of successful transactions using PayPal https://www.farmison.com/cp/listing/store_transaction?filters=eJxLtDK0qi62MrdSSk8sSS1PrFSyTrQyAglZWikVlibmZKZlphYpWRcDBZUyi0EMMyulssSc0tRikFKg7kwrA4hoQWJlQWKOknVtbS0AtowbvQ%253D%253D

Staged on https://steak-farmison-anya.d3r.com/. As the API behaviour is inconsistent for test you'll just have to make sure you can still place orders using PayPal.